### PR TITLE
feature: Create registry.go(CarOwnerHandler_DI)

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
+	github.com/lib/pq v1.10.9
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.6.0
 )

--- a/api/go.sum
+++ b/api/go.sum
@@ -110,6 +110,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/api/main.go
+++ b/api/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"log"
-	"fmt"
 	"net/http"
 	"github.com/taatolu/ParkingHub/api/registry"
 	presentation "github.com/taatolu/ParkingHub/api/presentation/http"

--- a/api/main.go
+++ b/api/main.go
@@ -1,11 +1,22 @@
 package main
 
 import (
+	"log"
 	"fmt"
 	"net/http"
+	"github.com/taatolu/ParkingHub/api/registry"
+	presentation "github.com/taatolu/ParkingHub/api/presentation/http"
 )
 
 func main() {
-	fmt.Println("取り急ぎ起動")
-	http.ListenAndServe(":8080", nil) //とりあえずデフォルトのマルチプレクサでサーバ起動
+	reg := registry.NewRegistry()
+	defer reg.Close()	//アプリ終了時に安全にDBクローズするためにregistry.goに作成したもの
+
+	router := presentation.InitRouters(reg)
+
+	log.Println("サーバ起動: http://localhost:8080")
+	err := http.ListenAndServe(":8080", router) //作成したマルチプレクサでサーバ起動
+	if err != nil{
+		log.Fatal(err)
+	}
 }

--- a/api/presentation/http/router.go
+++ b/api/presentation/http/router.go
@@ -2,7 +2,8 @@ package http
 
 import (
     "net/http"
-    "github.com/taatolu/ParkingHub/api/presentation/http/handler"
+    "github.com/taatolu/ParkingHub/api/registry"
+    _ "github.com/taatolu/ParkingHub/api/presentation/http/handler"
     )
 
 func InitRouters(reg *registry.Registry)http.Handler{

--- a/api/presentation/http/router.go
+++ b/api/presentation/http/router.go
@@ -5,8 +5,10 @@ import (
     "github.com/taatolu/ParkingHub/api/presentation/http/handler"
     )
 
-func InitRouters()http.Handler{
-    http.Handle("/api/v1/car_owners", &handler.CarOwnerHandler{})   //GET(ALL),POST メソッド
+func InitRouters(reg *registry.Registry)http.Handler{
+    //マルチプレクサを作成
+    mux := http.NewServeMux()
+    mux.Handle("/api/v1/car_owners", reg.NewCarOwnerHandler())   //GET(ALL),POST メソッド
     //http.Handle("/api/v1/car_owners/", &handler.CarOwnersHandler{})    //GET,PUSH,DELETE メソッド
-    return http.DefaultServeMux
+    return mux
 }

--- a/api/registry/registry.go
+++ b/api/registry/registry.go
@@ -2,6 +2,7 @@ package registry
 
 import(
     "database/sql"
+    "fmt"
     "github.com/taatolu/ParkingHub/api/config"
     "github.com/taatolu/ParkingHub/api/infrastructure/postgres"
     _ "github.com/taatolu/ParkingHub/api/domain/service"
@@ -62,7 +63,7 @@ func (r *Registry) NewCarOwnerUsecase() usecase.CarOwnerUsecaseIF {
 func (r *Registry) NewCarOwnerHandler() *handler.CarOwnerHandler {
     //*返り値が構造体の場合、ポインタ型は返せません（handler.CarOwnerHandlerは構造体なので、”*”をつけてポインタで返すようにした）
     return &handler.CarOwnerHandler{
-        Usecase: r.NewCarOwnerUsecase()
+        Usecase: r.NewCarOwnerUsecase(),
     }
 }
 


### PR DESCRIPTION
# registry.go
- HandlerのDIを実装
- Registry Close() を実装
- 【非実装】InitRouter()......今回はこれをmain.goで実装するようにした

# router.go
- Routerのイニシャライズで、registryで作成したHandlerを使用するように変更

# main.go
- ルーターを作成し、この作成したルーターをサーバ起動（リッスンアンドサーブ）で使用