### PR TITLE
fix: Update config.go

### DIFF
--- a/api/config/config.go
+++ b/api/config/config.go
@@ -19,11 +19,13 @@ func LoadConfig() (*Config, error) {
 	viper.AddConfigPath(".") //ここまでで、config.iniというファイルを指定
 	viper.AutomaticEnv()     //環境変数を優先するように指示
 
-	//viperを使用して設定ファイル（.env/ini）を読込む
-	err := viper.ReadInConfig()
-	if err != nil {
-		return nil, fmt.Errorf("設定ファイル読込失敗 %w", err)
-	}
+    err := viper.ReadInConfig()
+    if err != nil {
+        // 設定ファイル(config.ini)が見つからない場合は無視
+        if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+            return nil, fmt.Errorf("設定ファイル読込失敗 %w", err)
+        }
+    }
 
 	//上記viperで読込んだ設定情報をconfig構造体にマッピング
 


### PR DESCRIPTION
viperの設定でDocker-composeで.envのデータを環境変数として受け取ったときは
configh.iniを使用しないようにしていた。
この設定に問題はないが、それでもconfig.iniを探す挙動はするので、この段階で”fileが見つからない”とエラーを吐く。

上記”fileが見つからない”のエラーは無視するように変更