### PR TITLE
Add DockerFile(/api)

### DIFF
--- a/api/DockerFile
+++ b/api/DockerFile
@@ -1,0 +1,18 @@
+From golang:1.13
+
+# 作業ディレクトリを設定
+WORKDIR /go/src/app
+
+# カレントディレクトリの内容をコンテナにコピー
+COPY . .
+
+# 必要なGoモジュールをインストール
+RUN go mod tidy
+
+# golang-migrateをインストール（Go 1.13の場合は go get を推奨）
+RUN go get -u github.com/golang-migrate/migrate/v4/cmd/migrate
+
+# APIサーバのビルドなども追記
+# 本番用なら go build でバイナリを作成しCMDで実行
+# 開発運用の場合は go run でOK
+CMD ["go", "run", "main.go"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,11 @@ services:
             - db_parkinghub:/var/lib/
             
     api:
-        image: golang:1.13
-        working_dir: /go/src/app
+        build: ./api
         volumes:
             - type: bind
               source: ./api
               target: /go/src/app
-        command: go run main.go
         environment:
             #環境変数の設定
             #直書き非推奨なので、ホストの.envから取得


### PR DESCRIPTION
golang-migrateをインストールするにあたり、
バックエンドをDocker-compose,ymlだけでビルドしていた状況から
Docker-compose,yml + DockerFile　に切り分け