### PR TITLE
feature:#54 Create HanlerTest_Mock(FindByID)

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -1,42 +1,42 @@
 package main
 
 import (
-	"log"
-	"net/http"
 	"github.com/taatolu/ParkingHub/api/config"
-	"github.com/taatolu/ParkingHub/api/registry"
 	"github.com/taatolu/ParkingHub/api/infrastructure/migrate"
 	presentation "github.com/taatolu/ParkingHub/api/presentation/http"
+	"github.com/taatolu/ParkingHub/api/registry"
+	"log"
+	"net/http"
 )
 
 func main() {
 	//configの設定
 	conf, err := config.LoadConfig()
 	if err != nil {
-        log.Fatal("設定読み込み失敗:", err)
-    }
+		log.Fatal("設定読み込み失敗:", err)
+	}
 
 	// デバッグ用ログ（一時的に追加）
-    log.Printf("=== 設定確認 ===")
-    log.Printf("DB_HOST: '%s'", conf.DBHost)
-    log.Printf("DB_NAME: '%s'", conf.DBName)
-    log.Printf("DB_USER: '%s'", conf.DBUser)
-    log.Printf("DB_PASSWORD: '%s'", conf.DBPass)
-    log.Printf("================")
+	log.Printf("=== 設定確認 ===")
+	log.Printf("DB_HOST: '%s'", conf.DBHost)
+	log.Printf("DB_NAME: '%s'", conf.DBName)
+	log.Printf("DB_USER: '%s'", conf.DBUser)
+	log.Printf("DB_PASSWORD: '%s'", conf.DBPass)
+	log.Printf("================")
 
 	//DBbのマイグレーション
 	if err := migrate.RunMigration(*conf); err != nil {
-	log.Fatal("マイグレーション失敗:", err)
-    }
+		log.Fatal("マイグレーション失敗:", err)
+	}
 
 	reg := registry.NewRegistry()
-	defer reg.Close()	//アプリ終了時に安全にDBクローズするためにregistry.goに作成したもの
+	defer reg.Close() //アプリ終了時に安全にDBクローズするためにregistry.goに作成したもの
 
 	router := presentation.InitRouters(reg)
 
 	log.Println("サーバ起動: http://localhost:8080")
 	err = http.ListenAndServe(":8080", router) //作成したマルチプレクサでサーバ起動
-	if err != nil{
+	if err != nil {
 		log.Fatal(err)
 	}
 }

--- a/api/presentation/http/handler/carowner_handler.go
+++ b/api/presentation/http/handler/carowner_handler.go
@@ -7,35 +7,21 @@ import (
 	"github.com/taatolu/ParkingHub/api/usecase"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 )
-
-type CarOwnersHandler struct {
-	//usecase層のインターフェースから実装
-	Usecase usecase.CarOwnerUsecaseIF
-}
 
 type CarOwnerHandler struct {
 	//usecase層のインターフェースから実装
 	Usecase usecase.CarOwnerUsecaseIF
 }
 
-// CarOwnersHandler definition（ルーターでCarOwnersHandlerが呼ばれたときどのメソッドを実行するか & ServeHTTPをラップ）
-func (h CarOwnersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case http.MethodPost:
-		h.CreateCarOwner(w, r)
-	default:
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusMethodNotAllowed)
-		w.Write([]byte(fmt.Sprintf(`{"error":"リクエストメソッドが不正です"}`)))
-	}
-}
-
 // CarOwnerHandler definition（ルーターでCarOwnerHandlerが呼ばれたときどのメソッドを実行するか & ServeHTTPをラップ）
 func (h CarOwnerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case http.MethodGet:
+	switch {
+	case r.URL.Path == "/api/v1/car_owners" && r.Method == http.MethodPost:
+		h.CreateCarOwner(w, r)
+	case strings.HasPrefix(r.URL.Path, "/api/v1/car_owners/") && r.Method == http.MethodGet:
 		h.FindByID(w, r)
 	default:
 		w.Header().Set("Content-Type", "application/json")
@@ -45,7 +31,7 @@ func (h CarOwnerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // POST api car_owners
-func (h CarOwnersHandler) CreateCarOwner(w http.ResponseWriter, r *http.Request) {
+func (h CarOwnerHandler) CreateCarOwner(w http.ResponseWriter, r *http.Request) {
 	//リクエストボディの内容を取得
 	///取得したリクエストボディの内容を格納する構造体を作成
 	var param struct {

--- a/api/presentation/http/handler/carowner_handler.go
+++ b/api/presentation/http/handler/carowner_handler.go
@@ -85,18 +85,21 @@ func (h CarOwnerHandler) CreateCarOwner(w http.ResponseWriter, r *http.Request) 
 // TODO: handlerを本実装に差し替える（Issue #54）
 func (h CarOwnerHandler) FindByID(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Path
-
-	//サンプルとして泥臭く正規表現処理でパスパラメータを取得した場合
-	parts := strings.Split(path, "/")
-
-	//パスパラメータなしの場合
-	if parts[4] == ""{
-		http.Error(w, "error:パスパラメータがありません", http.StatusBadRequest)
-		return
+    
+    //パス形式の検証: /api/v1/car_owners/{id}
+    if !strings.HasPrefix(path, "/api/v1/car_owners/"){
+        http.Error(w, "パスが不正です", http.StatusBadRequest)
+        return
+    }
+	//パラメータを取得（パスから"/api/v1/car_owners/"を引く）
+	idStr := strings.TrimPrefix(path, "/api/v1/car_owners/")
+	if idStr == "" {
+	    http.Error(w, "パラメータが存在しません", http.StatusBadRequest)
+	    return
 	}
 
 	//パスパラメータが数値に変換できない場合
-	id, err := strconv.Atoi(parts[4])
+	id, err := strconv.Atoi(idStr)
 	if err != nil {
 		http.Error(w, "error:パスパラメータが数値でありません", http.StatusBadRequest)
 		return

--- a/api/presentation/http/handler/carowner_handler.go
+++ b/api/presentation/http/handler/carowner_handler.go
@@ -108,7 +108,7 @@ func (h CarOwnerHandler) FindByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 一時的なレスポンス きちんとCarOwnerの構造体を返すように修正する（Issue #54）
+	// CarOwnerの構造体を返す
     w.Header().Set("Content-Type", "application/json")
     w.WriteHeader(http.StatusOK)
     if err = json.NewEncoder(w).Encode(owner); err != nil {

--- a/api/presentation/http/handler/carowner_handler.go
+++ b/api/presentation/http/handler/carowner_handler.go
@@ -1,99 +1,102 @@
 package handler
 
-import(
-    "strconv"
-    "encoding/json"
-    "net/http"
-    "time"
-    "fmt"
-    "github.com/taatolu/ParkingHub/api/usecase"
-    "github.com/taatolu/ParkingHub/api/domain/model"
-    )
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/taatolu/ParkingHub/api/domain/model"
+	"github.com/taatolu/ParkingHub/api/usecase"
+	"net/http"
+	"strconv"
+	"time"
+)
 
-type CarOwnersHandler struct{
-    //usecase層のインターフェースから実装
-    Usecase usecase.CarOwnerUsecaseIF
+type CarOwnersHandler struct {
+	//usecase層のインターフェースから実装
+	Usecase usecase.CarOwnerUsecaseIF
 }
 
-type CarOwnerHandler struct{
-    //usecase層のインターフェースから実装
-    Usecase usecase.CarOwnerUsecaseIF
+type CarOwnerHandler struct {
+	//usecase層のインターフェースから実装
+	Usecase usecase.CarOwnerUsecaseIF
 }
 
 // CarOwnersHandler definition（ルーターでCarOwnersHandlerが呼ばれたときどのメソッドを実行するか & ServeHTTPをラップ）
-func (h CarOwnersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request){
-    switch r.Method {
-    case http.MethodPost:  h.CreateCarOwner(w, r)
-    default:    w.Header().Set("Content-Type", "application/json")
-                w.WriteHeader(http.StatusMethodNotAllowed)
-                w.Write([]byte(fmt.Sprintf(`{"error":"リクエストメソッドが不正です"}`)))
-    }
+func (h CarOwnersHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.CreateCarOwner(w, r)
+	default:
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		w.Write([]byte(fmt.Sprintf(`{"error":"リクエストメソッドが不正です"}`)))
+	}
 }
 
 // CarOwnerHandler definition（ルーターでCarOwnerHandlerが呼ばれたときどのメソッドを実行するか & ServeHTTPをラップ）
-func (h CarOwnerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request){
-    switch r.Method {
-    case http.MethodGet:  h.FindByID(w, r)
-    default:    w.Header().Set("Content-Type", "application/json")
-                w.WriteHeader(http.StatusMethodNotAllowed)
-                w.Write([]byte(fmt.Sprintf(`{"error":"リクエストメソッドが不正です"}`)))
-    }
+func (h CarOwnerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.FindByID(w, r)
+	default:
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		w.Write([]byte(fmt.Sprintf(`{"error":"リクエストメソッドが不正です"}`)))
+	}
 }
 
+// POST api car_owners
+func (h CarOwnersHandler) CreateCarOwner(w http.ResponseWriter, r *http.Request) {
+	//リクエストボディの内容を取得
+	///取得したリクエストボディの内容を格納する構造体を作成
+	var param struct {
+		ID                string `json:"id"`
+		FirstName         string `json:"first_name"`
+		MiddleName        string `json:"middle_name"`
+		LastName          string `json:"last_name"`
+		LicenseExpiration string `json:"license_expiration"`
+	}
+	///リクエストボディの内容をparamにパース
+	err := json.NewDecoder(r.Body).Decode(&param)
+	if err != nil {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
 
-//POST api car_owners
-func (h CarOwnersHandler) CreateCarOwner(w http.ResponseWriter, r *http.Request){
-    //リクエストボディの内容を取得
-    ///取得したリクエストボディの内容を格納する構造体を作成
-    var param struct{
-        ID          string  `json:"id"`
-        FirstName   string  `json:"first_name"`
-        MiddleName  string  `json:"middle_name"`
-        LastName    string  `json:"last_name"`
-        LicenseExpiration   string  `json:"license_expiration"`
-    }
-    ///リクエストボディの内容をparamにパース
-    err := json.NewDecoder(r.Body).Decode(&param)
-    if err != nil{
-        http.Error(w, "Invalid request", http.StatusBadRequest)
-        return
-    }
-    
-    //取得したリクエストボディの型（取得時は文字列）をエンティティの型と一致するよう修正
-    idInt, err := strconv.Atoi(param.ID)
-    if err != nil{
-        http.Error(w, "IDの型変換に失敗", http.StatusBadRequest)
-        return
-    }
-    
-    expiry, err := time.Parse("2006-01-02", param.LicenseExpiration)
-    if err != nil {
-        http.Error(w, "Invalid LicenseExpiration format", http.StatusBadRequest)
-        return
-    }
-    
-    //model構築
-    owner := &model.CarOwner{
-        ID: idInt,
-        FirstName:  param.FirstName,
-        MiddleName: param.MiddleName,
-        LastName:   param.LastName,
-        // 文字列 → time.Time変換する処理が必要
-        LicenseExpiration:  expiry,
-    }
-    
-    // ユースケースを呼んで新規登録
-    err = h.Usecase.RegistCarOwner(owner)
-    if err != nil {
-        http.Error(w, err.Error(), http.StatusBadRequest)
-        return
-    }
-    
-    w.WriteHeader(http.StatusCreated)
-    json.NewEncoder(w).Encode(owner)
+	//取得したリクエストボディの型（取得時は文字列）をエンティティの型と一致するよう修正
+	idInt, err := strconv.Atoi(param.ID)
+	if err != nil {
+		http.Error(w, "IDの型変換に失敗", http.StatusBadRequest)
+		return
+	}
+
+	expiry, err := time.Parse("2006-01-02", param.LicenseExpiration)
+	if err != nil {
+		http.Error(w, "Invalid LicenseExpiration format", http.StatusBadRequest)
+		return
+	}
+
+	//model構築
+	owner := &model.CarOwner{
+		ID:         idInt,
+		FirstName:  param.FirstName,
+		MiddleName: param.MiddleName,
+		LastName:   param.LastName,
+		// 文字列 → time.Time変換する処理が必要
+		LicenseExpiration: expiry,
+	}
+
+	// ユースケースを呼んで新規登録
+	err = h.Usecase.RegistCarOwner(owner)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(owner)
 }
 
 // TODO: handlerを本実装に差し替える（Issue #54）
 func (h CarOwnerHandler) FindByID(w http.ResponseWriter, r *http.Request) {
-    return     // TODO: 実装内容に合わせて後で修正
+	return // TODO: 実装内容に合わせて後で修正
 }

--- a/api/presentation/http/handler/carowner_handler.go
+++ b/api/presentation/http/handler/carowner_handler.go
@@ -91,14 +91,14 @@ func (h CarOwnerHandler) FindByID(w http.ResponseWriter, r *http.Request) {
 
 	//パスパラメータなしの場合
 	if parts[4] == ""{
-		http.Error(w, "パスパラメータがありません", http.StatusBadRequest)
+		http.Error(w, "error:パスパラメータがありません", http.StatusBadRequest)
 		return
 	}
 
 	//パスパラメータが数値に変換できない場合
 	id, err := strconv.Atoi(parts[4])
 	if err != nil {
-		http.Error(w, "パスパラメータが数値でありません", http.StatusBadRequest)
+		http.Error(w, "error:パスパラメータが数値でありません", http.StatusBadRequest)
 		return
 	}
 
@@ -112,7 +112,7 @@ func (h CarOwnerHandler) FindByID(w http.ResponseWriter, r *http.Request) {
     w.Header().Set("Content-Type", "application/json")
     w.WriteHeader(http.StatusOK)
     if err = json.NewEncoder(w).Encode(owner); err != nil {
-        http.Error(w, "エンコード失敗", http.StatusInternalServerError)
+        http.Error(w, "error:エンコード失敗", http.StatusInternalServerError)
     }
 
 }

--- a/api/presentation/http/handler/carowner_handler.go
+++ b/api/presentation/http/handler/carowner_handler.go
@@ -111,10 +111,8 @@ func (h CarOwnerHandler) FindByID(w http.ResponseWriter, r *http.Request) {
 	// 一時的なレスポンス きちんとCarOwnerの構造体を返すように修正する（Issue #54）
     w.Header().Set("Content-Type", "application/json")
     w.WriteHeader(http.StatusOK)
-    response := map[string]interface{}{
-        "id": id,
-        "message": "User found",
+    if err = json.NewEncoder(w).Encode(owner); err != nil {
+        http.Error(w, "エンコード失敗", http.StatusInternalServerError)
     }
-    json.NewEncoder(w).Encode(response)
 
 }

--- a/api/presentation/http/handler/carowner_handler.go
+++ b/api/presentation/http/handler/carowner_handler.go
@@ -88,13 +88,13 @@ func (h CarOwnerHandler) FindByID(w http.ResponseWriter, r *http.Request) {
     
     //パス形式の検証: /api/v1/car_owners/{id}
     if !strings.HasPrefix(path, "/api/v1/car_owners/"){
-        http.Error(w, "パスが不正です", http.StatusBadRequest)
+        http.Error(w, "error:パスが不正です", http.StatusBadRequest)
         return
     }
 	//パラメータを取得（パスから"/api/v1/car_owners/"を引く）
 	idStr := strings.TrimPrefix(path, "/api/v1/car_owners/")
 	if idStr == "" {
-	    http.Error(w, "パラメータが存在しません", http.StatusBadRequest)
+	    http.Error(w, "error:パラメータが存在しません", http.StatusBadRequest)
 	    return
 	}
 

--- a/api/presentation/http/handler/carowner_handler.go
+++ b/api/presentation/http/handler/carowner_handler.go
@@ -84,5 +84,37 @@ func (h CarOwnerHandler) CreateCarOwner(w http.ResponseWriter, r *http.Request) 
 
 // TODO: handlerを本実装に差し替える（Issue #54）
 func (h CarOwnerHandler) FindByID(w http.ResponseWriter, r *http.Request) {
-	return // TODO: 実装内容に合わせて後で修正
+	path := r.URL.Path
+
+	//サンプルとして泥臭く正規表現処理でパスパラメータを取得した場合
+	parts := strings.Split(path, "/")
+
+	//パスパラメータなしの場合
+	if parts[4] == ""{
+		http.Error(w, "パスパラメータがありません", http.StatusBadRequest)
+		return
+	}
+
+	//パスパラメータが数値に変換できない場合
+	id, err := strconv.Atoi(parts[4])
+	if err != nil {
+		http.Error(w, "パスパラメータが数値でありません", http.StatusBadRequest)
+		return
+	}
+
+	owner, err := h.Usecase.FindByID(id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	// 一時的なレスポンス きちんとCarOwnerの構造体を返すように修正する（Issue #54）
+    w.Header().Set("Content-Type", "application/json")
+    w.WriteHeader(http.StatusOK)
+    response := map[string]interface{}{
+        "id": id,
+        "message": "User found",
+    }
+    json.NewEncoder(w).Encode(response)
+
 }

--- a/api/presentation/http/handler/fake_carowner_test.go
+++ b/api/presentation/http/handler/fake_carowner_test.go
@@ -1,114 +1,113 @@
 package handler
 
-import(
-    "testing"
-	"net/http/httptest"
-	"net/http"
-	"strings"
+import (
+	"bytes"
+	"github.com/taatolu/ParkingHub/api/mocks/usecase"
 	"io"
 	"io/ioutil"
-	"bytes"
-    "github.com/taatolu/ParkingHub/api/mocks/usecase"
-    )
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
 
-func TestRegistCarOwner_FakeUsecase(t *testing.T){
-    //tableTest
-    tests := [] struct {
-        testname    string
-        method      string
-        url         string
-        body        io.Reader
-        wantError   bool
-    }{
-        //テストケースの作成
-        {
-            testname:   "正常系",
-            method:     "POST",
-            url:        "/api/v1/car_owners",
-            body:       bytes.NewBufferString(`{"id":"1",
+func TestRegistCarOwner_FakeUsecase(t *testing.T) {
+	//tableTest
+	tests := []struct {
+		testname  string
+		method    string
+		url       string
+		body      io.Reader
+		wantError bool
+	}{
+		//テストケースの作成
+		{
+			testname: "正常系",
+			method:   "POST",
+			url:      "/api/v1/car_owners",
+			body: bytes.NewBufferString(`{"id":"1",
                                                 "first_name":"test",
                                                 "middle_name":"山田",
                                                 "last_name":"太郎",
                                                 "license_expiration":"2030-12-31"}`),
-            wantError:  false,
-        },
-        {
-            testname:   "異常系（name入力不足）",
-            method:     "POST",
-            url:        "/api/v1/car_owners",
-            body:       bytes.NewBufferString(`{"id":"1",
+			wantError: false,
+		},
+		{
+			testname: "異常系（name入力不足）",
+			method:   "POST",
+			url:      "/api/v1/car_owners",
+			body: bytes.NewBufferString(`{"id":"1",
                                                 "first_name":"",
                                                 "middle_name":"",
                                                 "last_name":"太郎",
                                                 "license_expiration":"2030-12-31"}`),
-            wantError:  true,
-        },
-        {
-            testname:   "異常系（免許期限切れ）",
-            method:     "POST",
-            url:        "/api/v1/car_owners",
-            body:       bytes.NewBufferString(`{"id":"1",
+			wantError: true,
+		},
+		{
+			testname: "異常系（免許期限切れ）",
+			method:   "POST",
+			url:      "/api/v1/car_owners",
+			body: bytes.NewBufferString(`{"id":"1",
                                                 "first_name":"test",
                                                 "middle_name":"山田",
                                                 "last_name":"太郎",
                                                 "license_expiration":"2020-12-31"}`),
-            wantError:  true,
-        },
-    }
-    //テストケースをループで回す
-    for _, tt := range tests {
-        t.Run(tt.testname, func(t *testing.T){
-            //CarOwnerUsecaseフェイクのインスタンス化
-            fakeUsecase := &usecase.FakeCarOwnerUsecase{}
-            
-            //ハンドラーのインスタンス生成
-            handler := &CarOwnersHandler{Usecase: fakeUsecase}
-            
-            // httptest.NewRecorder() でレスポンス記録
-            rec := httptest.NewRecorder()
-            
-            // http.NewRequest() でリクエスト作成
-        
-            req, err := http.NewRequest(tt.method, tt.url, tt.body)
-            if err != nil {
-                t.Fatal(err)
-            }
-            req.Header.Set("Content-Type", "application/json")
-            
-            // handler.ServeHTTPで実行
-            handler.ServeHTTP(rec, req)
-            
-            // recorder.Result() でレスポンス検証
-            resp := rec.Result()
-            defer resp.Body.Close()
-            
-            //respからBodyの値を取得
-            bodyBytes, _ := ioutil.ReadAll(resp.Body)
-            bodyString := string(bodyBytes)
-            
-            if tt.wantError{
-                //wantErrorがtrue　=　異常系だったら
-                if resp.StatusCode == http.StatusCreated {
-                    t.Errorf("異常系なのに201が返っています")
-                }
-                switch tt.testname {
-                case "異常系（name入力不足）":
-                    if !strings.Contains(bodyString, "少なくとも２つ以上のフィールドに名前を入力ください") {
-                        t.Errorf("エラーメッセージが含まれていません: %s", bodyString)
-                    }
-                case "異常系（免許期限切れ）":
-                    if !strings.Contains(bodyString, "免許証期限切れの為登録不可") {
-                        t.Errorf("エラーメッセージが含まれていません: %s", bodyString)
-                    }
-                }
-            }else{
-                //wantErrorがfalse　=　正常系だったら
-                if resp.StatusCode != http.StatusCreated {
-                    t.Errorf("GotStatus=%d WantStatus=%d", resp.StatusCode, http.StatusCreated)
-                }
-            }
-            
-            
-        })
-    }
+			wantError: true,
+		},
+	}
+	//テストケースをループで回す
+	for _, tt := range tests {
+		t.Run(tt.testname, func(t *testing.T) {
+			//CarOwnerUsecaseフェイクのインスタンス化
+			fakeUsecase := &usecase.FakeCarOwnerUsecase{}
+
+			//ハンドラーのインスタンス生成
+			handler := &CarOwnersHandler{Usecase: fakeUsecase}
+
+			// httptest.NewRecorder() でレスポンス記録
+			rec := httptest.NewRecorder()
+
+			// http.NewRequest() でリクエスト作成
+
+			req, err := http.NewRequest(tt.method, tt.url, tt.body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+
+			// handler.ServeHTTPで実行
+			handler.ServeHTTP(rec, req)
+
+			// recorder.Result() でレスポンス検証
+			resp := rec.Result()
+			defer resp.Body.Close()
+
+			//respからBodyの値を取得
+			bodyBytes, _ := ioutil.ReadAll(resp.Body)
+			bodyString := string(bodyBytes)
+
+			if tt.wantError {
+				//wantErrorがtrue　=　異常系だったら
+				if resp.StatusCode == http.StatusCreated {
+					t.Errorf("異常系なのに201が返っています")
+				}
+				switch tt.testname {
+				case "異常系（name入力不足）":
+					if !strings.Contains(bodyString, "少なくとも２つ以上のフィールドに名前を入力ください") {
+						t.Errorf("エラーメッセージが含まれていません: %s", bodyString)
+					}
+				case "異常系（免許期限切れ）":
+					if !strings.Contains(bodyString, "免許証期限切れの為登録不可") {
+						t.Errorf("エラーメッセージが含まれていません: %s", bodyString)
+					}
+				}
+			} else {
+				//wantErrorがfalse　=　正常系だったら
+				if resp.StatusCode != http.StatusCreated {
+					t.Errorf("GotStatus=%d WantStatus=%d", resp.StatusCode, http.StatusCreated)
+				}
+			}
+
+		})
+	}
 }

--- a/api/presentation/http/handler/fake_carowner_test.go
+++ b/api/presentation/http/handler/fake_carowner_test.go
@@ -62,7 +62,7 @@ func TestRegistCarOwner_FakeUsecase(t *testing.T) {
 			fakeUsecase := &usecase.FakeCarOwnerUsecase{}
 
 			//ハンドラーのインスタンス生成
-			handler := &CarOwnersHandler{Usecase: fakeUsecase}
+			handler := &CarOwnerHandler{Usecase: fakeUsecase}
 
 			// httptest.NewRecorder() でレスポンス記録
 			rec := httptest.NewRecorder()

--- a/api/presentation/http/handler/mock_carowner_handler_test.go
+++ b/api/presentation/http/handler/mock_carowner_handler_test.go
@@ -100,4 +100,52 @@ func TestRegistCarOwner(t *testing.T){
     }
 }
 
+func TestFindByID(t *testing.T){
+    //tableTest
+    tests := []struct{
+        testname    string
+        method      string
+        url         string
+        wantError   bool
+    }{
+        //testcae作成
+        {
+            testname:   "正常系",
+            method:     "GET",
+            url:        "/api/v1/car_owners/1",
+            wantError:  false,
+        },
+        {
+            testname:   "異常系（メソッド不正）",
+            method:     "POSTPOST",
+            url:        "/api/v1/car_owners/",
+            wantError:  true,
+        },
+        {
+            testname:   "異常系（url不正：パスパラメータ無し）",
+            method:     "GET",
+            url:        "/api/v1/car_owners/",
+            wantError:  true,
+        }
+    }
+    //testをループ処理する
+    for _, tt := range tests {
+        t.Run(tt.testname, func(t *testing.T){
+            
+            //まずはハンドラにDIするためのCarOwnerUsecaseモックのインスタンスを生成
+            mockUsecase := &usecase.MockCarOwnerUsecase{
+                FindByIDFunc:   func(id int)(*model.CarOwner, error){
+                    if id==1 && !tt.wantError {
+                        return &model.CarOwner{
+                            id:1,
+                            FirstName:  "Test",
+                            LastName:   "User",
+                        }, nil
+                    }
+                    
+                    return nil,  fmt.Errorf("インフラストラクチャ層の実装をしたときにデータが返ってこなかった体（テイ）")
+            }
+        })
+    }
+}
 

--- a/api/presentation/http/handler/mock_carowner_handler_test.go
+++ b/api/presentation/http/handler/mock_carowner_handler_test.go
@@ -1,15 +1,15 @@
 package handler
 
-import(
+import (
+	"bytes"
 	"github.com/taatolu/ParkingHub/api/domain/model"
 	"github.com/taatolu/ParkingHub/api/mocks/usecase"
-	"testing"
-	"net/http/httptest"
-	"net/http"
-	"strings"
 	"io"
-	"io/ioutil"
-	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
 )
 
 // このテストでは異常系として「URL不正（404）」は検証していません。
@@ -17,158 +17,176 @@ import(
 // ハンドラーレベルでその挙動をテストする意味が薄いからです。
 // 代わりに、method不正やbody不正など、ハンドラーが直接扱う異常系のみをテスト対象としています。
 
-
-func TestRegistCarOwner(t *testing.T){
-    //tableTest
-    tests := [] struct {
-        testname    string
-        method      string
-        url         string
-        body        io.Reader
-        wantError   bool
-    }{
-        //テストケースの作成
-        {
-            testname:   "正常系",
-            method:     "POST",
-            url:        "/api/v1/car_owners",
-            body:       bytes.NewBufferString(`{"id":"1",
+func TestRegistCarOwner(t *testing.T) {
+	//tableTest
+	tests := []struct {
+		testname  string
+		method    string
+		url       string
+		body      io.Reader
+		wantError bool
+	}{
+		//テストケースの作成
+		{
+			testname: "正常系",
+			method:   "POST",
+			url:      "/api/v1/car_owners",
+			body: bytes.NewBufferString(`{"id":"1",
                                                 "first_name":"test",
                                                 "middle_name":"山田",
                                                 "last_name":"太郎",
                                                 "license_expiration":"2030-12-31"}`),
-            wantError:  false,
-        },
-        {
-            testname:   "異常系（method不正）",
-            method:     "GET",
-            url:        "/api/v1/car_owners",
-            body:       bytes.NewBufferString(`{"id":"1"}`),
-            wantError:  true,
-        },
-    }
-    //テストケースをループで回す
-    for _, tt := range tests {
-        t.Run(tt.testname, func(t *testing.T){
-            //CarOwnerUsecaseモックのインスタンス化
-            mockUsecase := &usecase.MockCarOwnerUsecase{
-                RegistCarOwnerFunc : func(owner *model.CarOwner) error{
-                    return nil
-                },
-            }
-            
-            //ハンドラーのインスタンス生成
-            handler := &CarOwnersHandler{Usecase: mockUsecase}
-            
-            // httptest.NewRecorder() でレスポンス記録
-            rec := httptest.NewRecorder()
-            
-            // http.NewRequest() でリクエスト作成
-            req, err := http.NewRequest(tt.method, tt.url, tt.body)
-            if err != nil {
-                t.Fatal(err)
-            }
-            req.Header.Set("Content-Type", "application/json")
-            
-            // handler.ServeHTTPで実行
-            handler.ServeHTTP(rec, req)
-            
-            // recorder.Result() でレスポンス検証
-            resp := rec.Result()
-            defer resp.Body.Close()
-            
-            //respからBodyの値を取得
-            bodyBytes, _ := ioutil.ReadAll(resp.Body)
-            bodyString := string(bodyBytes)
-            
-            if tt.wantError{
-                //wantErrorがtrue　=　異常系だったら
-                if resp.StatusCode == http.StatusCreated {
-                    t.Errorf("異常系なのに201が返っています")
-                }
-                if !strings.Contains(bodyString, "error") && resp.StatusCode != http.StatusNotFound {
-                    t.Errorf("エラーメッセージが含まれていません: %s", bodyString)
-                }
-            }else{
-                //wantErrorがfalse　=　正常系だったら
-                if resp.StatusCode != http.StatusCreated {
-                    t.Errorf("GotStatus=%d WantStatus=%d", resp.StatusCode, http.StatusCreated)
-                }
-            }
-        })
-    }
+			wantError: false,
+		},
+		{
+			testname:  "異常系（method不正）",
+			method:    "GET",
+			url:       "/api/v1/car_owners",
+			body:      bytes.NewBufferString(`{"id":"1"}`),
+			wantError: true,
+		},
+	}
+	//テストケースをループで回す
+	for _, tt := range tests {
+		t.Run(tt.testname, func(t *testing.T) {
+			//CarOwnerUsecaseモックのインスタンス化
+			mockUsecase := &usecase.MockCarOwnerUsecase{
+				RegistCarOwnerFunc: func(owner *model.CarOwner) error {
+					return nil
+				},
+			}
+
+			//ハンドラーのインスタンス生成
+			handler := &CarOwnersHandler{Usecase: mockUsecase}
+
+			// httptest.NewRecorder() でレスポンス記録
+			rec := httptest.NewRecorder()
+
+			// http.NewRequest() でリクエスト作成
+			req, err := http.NewRequest(tt.method, tt.url, tt.body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+
+			// handler.ServeHTTPで実行
+			handler.ServeHTTP(rec, req)
+
+			// recorder.Result() でレスポンス検証
+			resp := rec.Result()
+			defer resp.Body.Close()
+
+			//respからBodyの値を取得
+			bodyBytes, _ := io.ReadAll(resp.Body)
+			bodyString := string(bodyBytes)
+
+			if tt.wantError {
+				//wantErrorがtrue　=　異常系だったら
+				if resp.StatusCode == http.StatusCreated {
+					t.Errorf("異常系なのに201が返っています")
+				}
+				if !strings.Contains(bodyString, "error") && resp.StatusCode != http.StatusNotFound {
+					t.Errorf("エラーメッセージが含まれていません: %s", bodyString)
+				}
+			} else {
+				//wantErrorがfalse　=　正常系だったら
+				if resp.StatusCode != http.StatusCreated {
+					t.Errorf("GotStatus=%d WantStatus=%d", resp.StatusCode, http.StatusCreated)
+				}
+			}
+		})
+	}
 }
 
-func TestFindByID(t *testing.T){
-    //tableTest
-    tests := []struct{
-        testname    string
-        method      string
-        url         string
-        wantError   bool
-    }{
-        //testcae作成
-        {
-            testname:   "正常系",
-            method:     "GET",
-            url:        "/api/v1/car_owners/1",
-            wantError:  false,
-        },
-        {
-            testname:   "異常系（メソッド不正）",
-            method:     "POSTPOST",
-            url:        "/api/v1/car_owners/",
-            wantError:  true,
-        },
-        {
-            testname:   "異常系（url不正：パスパラメータ無し）",
-            method:     "GET",
-            url:        "/api/v1/car_owners/",
-            wantError:  true,
-        }
-    }
-    //testをループ処理する
-    for _, tt := range tests {
-        t.Run(tt.testname, func(t *testing.T){
-            
-            //まずはハンドラにDIするためのCarOwnerUsecaseモックのインスタンスを生成
-            mockUsecase := &usecase.MockCarOwnerUsecase{
-                FindByIDFunc:   func(id int)(*model.CarOwner, error){
-                    if id==1 && !tt.wantError {
-                        return &model.CarOwner{
-                            id:1,
-                            FirstName:  "Test",
-                            LastName:   "User",
-                        }, nil
-                    }
-                    return nil,  fmt.Errorf("インフラストラクチャ層の実装をしたときにデータが返ってこなかった体（テイ）")
-            }
+func TestFindByID(t *testing.T) {
+	//tableTest
+	tests := []struct {
+		testname  string
+		method    string
+		url       string
+		wantError bool
+	}{
+		//testcae作成
+		{
+			testname:  "正常系",
+			method:    "GET",
+			url:       "/api/v1/car_owners/1",
+			wantError: false,
+		},
+		{
+			testname:  "異常系（メソッド不正）",
+			method:    "POST",
+			url:       "/api/v1/car_owners/",
+			wantError: true,
+		},
+		{
+			testname:  "異常系（url不正：パスパラメータ無し）",
+			method:    "GET",
+			url:       "/api/v1/car_owners/",
+			wantError: true,
+		},
+	}
+	//testをループ処理する
+	for _, tt := range tests {
+		t.Run(tt.testname, func(t *testing.T) {
 
-            //handlerのインスタンス生成(上で作成したCarOwnerUsecaseのモックをDI)
-            handler := &CarOwnerHandler{Usecase:mockUsecase}
+			//まずはハンドラにDIするためのCarOwnerUsecaseモックのインスタンスを生成
+			mockUsecase := &usecase.MockCarOwnerUsecase{
+				FindByIDFunc: func(id int) (*model.CarOwner, error) {
+					if id == 1 && !tt.wantError {
+						return &model.CarOwner{
+							ID:        1,
+							FirstName: "Test",
+							LastName:  "User",
+						}, nil
+					}
+					return nil, fmt.Errorf("インフラストラクチャ層の実装をしたときにデータが返ってこなかった体（テイ）")
+				},
+			}
 
-            //http.NewRecorderでレスポンスを記録(テスト時にhttp.ResponseWriterの代わりで動くもの)
-            rec := httptest.NewRecorder
+			//handlerのインスタンス生成(上で作成したCarOwnerUsecaseのモックをDI)
+			handler := &CarOwnerHandler{Usecase: mockUsecase}
 
-            //http.NewRequest()でリクエスト作成
-            req, err := http.NewRequest(tt.method, tt.url)
-            if err != nil {
-                t.Fatal(err)
-            }
-            //リクエストのボディに JSON データを含める場合には以下の設定が必要です。
-            // しかし、FindByID のようにパスパラメータのみでリクエストし、ボディにデータを含めない場合は、Content-Type ヘッダーは不要
-            // req.Header.Set("Content-Type", "application/json")
-            //　※返却値（レスポンス）が JSON であれば、サーバー側が Content-Type: application/json を返しますが、リクエスト側で設定する必要はない
-            //【そもそも】テストのリクエストが GET メソッドで、ボディが空なら Content-Type ヘッダーは省略しましょう。
-            //         POST や PUT で JSON ボディを送る場合は必須です。
+			//http.NewRecorderでレスポンスを記録(テスト時にhttp.ResponseWriterの代わりで動くもの)
+			rec := httptest.NewRecorder()
 
-            //handler.ServeHttpで実行
-            handler.ServeHttp(rec, req)
+			//http.NewRequest()でリクエスト作成
+			req, err := http.NewRequest(tt.method, tt.url, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			//リクエストのボディに JSON データを含める場合には以下の設定が必要。
+			// だが、FindByID のようにパスパラメータのみでリクエストし、ボディにデータを含めない場合は、Content-Type ヘッダーは不要
+			// req.Header.Set("Content-Type", "application/json")
+			//　※返却値（レスポンス）が JSON であれば、サーバー側が Content-Type: application/json を返しますが、リクエスト側で設定する必要はない
+			//【そもそも】テストのリクエストが GET メソッドで、ボディが空なら Content-Type ヘッダーは省略しましょう。
+			//         POST や PUT で JSON ボディを送る場合は必須です。
 
-            //recorder.Resultでrec(http.ResponseWriterの代わりで動くもの)に帰ってきたレスポンスを検証
-            resp := rec.Result()
+			//handler.ServeHttpで実行
+			handler.ServeHTTP(rec, req)
 
-        })
-    }
+			//recorder.Resultでrec(http.ResponseWriterの代わりで動くもの)に帰ってきたレスポンスを検証
+			resp := rec.Result()
+			defer resp.Body.Close()
+
+			//respからBodyの値を取得
+			bodyBytes, _ := io.ReadAll(resp.Body)
+			bodyString := string(bodyBytes)
+
+			if tt.wantError {
+				//tt.wantErrorがtrue=異常値の場合
+				if resp.StatusCode == http.StatusOK{
+					t.Errorf("異常系なのに200番が返っています")
+				}
+				if resp.StatusCode != http.StatusNotFound && !strings.Contains(bodyString, "error") {
+					t.Error("エラーメッセージが含まれていません")
+				}
+			} else {
+				//tt.wantErrorがfalse=正常値の場合
+				if resp.StatusCode != http.StatusOK{
+					t.Errorf("Got:%d Want:%d", resp.StatusCode, http.StatusOK)
+				}
+			}
+		})
+	}
 }
-

--- a/api/presentation/http/handler/mock_carowner_handler_test.go
+++ b/api/presentation/http/handler/mock_carowner_handler_test.go
@@ -2,10 +2,10 @@ package handler
 
 import (
 	"bytes"
+	"fmt"
 	"github.com/taatolu/ParkingHub/api/domain/model"
 	"github.com/taatolu/ParkingHub/api/mocks/usecase"
 	"io"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -57,7 +57,7 @@ func TestRegistCarOwner(t *testing.T) {
 			}
 
 			//ハンドラーのインスタンス生成
-			handler := &CarOwnersHandler{Usecase: mockUsecase}
+			handler := &CarOwnerHandler{Usecase: mockUsecase}
 
 			// httptest.NewRecorder() でレスポンス記録
 			rec := httptest.NewRecorder()
@@ -175,7 +175,7 @@ func TestFindByID(t *testing.T) {
 
 			if tt.wantError {
 				//tt.wantErrorがtrue=異常値の場合
-				if resp.StatusCode == http.StatusOK{
+				if resp.StatusCode == http.StatusOK {
 					t.Errorf("異常系なのに200番が返っています")
 				}
 				if resp.StatusCode != http.StatusNotFound && !strings.Contains(bodyString, "error") {
@@ -183,7 +183,7 @@ func TestFindByID(t *testing.T) {
 				}
 			} else {
 				//tt.wantErrorがfalse=正常値の場合
-				if resp.StatusCode != http.StatusOK{
+				if resp.StatusCode != http.StatusOK {
 					t.Errorf("Got:%d Want:%d", resp.StatusCode, http.StatusOK)
 				}
 			}

--- a/api/presentation/http/handler/mock_carowner_handler_test.go
+++ b/api/presentation/http/handler/mock_carowner_handler_test.go
@@ -64,7 +64,6 @@ func TestRegistCarOwner(t *testing.T){
             rec := httptest.NewRecorder()
             
             // http.NewRequest() でリクエスト作成
-        
             req, err := http.NewRequest(tt.method, tt.url, tt.body)
             if err != nil {
                 t.Fatal(err)
@@ -142,9 +141,33 @@ func TestFindByID(t *testing.T){
                             LastName:   "User",
                         }, nil
                     }
-                    
                     return nil,  fmt.Errorf("インフラストラクチャ層の実装をしたときにデータが返ってこなかった体（テイ）")
             }
+
+            //handlerのインスタンス生成(上で作成したCarOwnerUsecaseのモックをDI)
+            handler := &CarOwnerHandler{Usecase:mockUsecase}
+
+            //http.NewRecorderでレスポンスを記録(テスト時にhttp.ResponseWriterの代わりで動くもの)
+            rec := httptest.NewRecorder
+
+            //http.NewRequest()でリクエスト作成
+            req, err := http.NewRequest(tt.method, tt.url)
+            if err != nil {
+                t.Fatal(err)
+            }
+            //リクエストのボディに JSON データを含める場合には以下の設定が必要です。
+            // しかし、FindByID のようにパスパラメータのみでリクエストし、ボディにデータを含めない場合は、Content-Type ヘッダーは不要
+            // req.Header.Set("Content-Type", "application/json")
+            //　※返却値（レスポンス）が JSON であれば、サーバー側が Content-Type: application/json を返しますが、リクエスト側で設定する必要はない
+            //【そもそも】テストのリクエストが GET メソッドで、ボディが空なら Content-Type ヘッダーは省略しましょう。
+            //         POST や PUT で JSON ボディを送る場合は必須です。
+
+            //handler.ServeHttpで実行
+            handler.ServeHttp(rec, req)
+
+            //recorder.Resultでrec(http.ResponseWriterの代わりで動くもの)に帰ってきたレスポンスを検証
+            resp := rec.Result()
+
         })
     }
 }

--- a/api/presentation/http/router.go
+++ b/api/presentation/http/router.go
@@ -9,7 +9,10 @@ import (
 func InitRouters(reg *registry.Registry) http.Handler {
 	//マルチプレクサを作成
 	mux := http.NewServeMux()
-	mux.Handle("/api/v1/car_owners", reg.NewCarOwnersHandler())   //GET(ALL),POST メソッド
-	mux.Handle("/api/v1/car_owners/", &handler.CarOwnerHandler{}) //GET,PUSH,DELETE メソッド
+
+	carOwnerHandler := reg.NewCarOwnerHandler()
+
+	mux.Handle("/api/v1/car_owners", carOwnerHandler)   //GET(ALL),POST メソッド
+	mux.Handle("/api/v1/car_owners/", carOwnerHandler) //GET,PUSH,DELETE メソッド
 	return mux
 }

--- a/api/presentation/http/router.go
+++ b/api/presentation/http/router.go
@@ -1,15 +1,15 @@
 package http
 
 import (
-    "net/http"
-    "github.com/taatolu/ParkingHub/api/registry"
-    "github.com/taatolu/ParkingHub/api/presentation/http/handler"
-    )
+	"github.com/taatolu/ParkingHub/api/presentation/http/handler"
+	"github.com/taatolu/ParkingHub/api/registry"
+	"net/http"
+)
 
-func InitRouters(reg *registry.Registry)http.Handler{
-    //マルチプレクサを作成
-    mux := http.NewServeMux()
-    mux.Handle("/api/v1/car_owners", reg.NewCarOwnersHandler())   //GET(ALL),POST メソッド
-    mux.Handle("/api/v1/car_owners/", &handler.CarOwnerHandler{})    //GET,PUSH,DELETE メソッド
-    return mux
+func InitRouters(reg *registry.Registry) http.Handler {
+	//マルチプレクサを作成
+	mux := http.NewServeMux()
+	mux.Handle("/api/v1/car_owners", reg.NewCarOwnersHandler())   //GET(ALL),POST メソッド
+	mux.Handle("/api/v1/car_owners/", &handler.CarOwnerHandler{}) //GET,PUSH,DELETE メソッド
+	return mux
 }

--- a/api/presentation/http/router.go
+++ b/api/presentation/http/router.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"github.com/taatolu/ParkingHub/api/presentation/http/handler"
 	"github.com/taatolu/ParkingHub/api/registry"
 	"net/http"
 )

--- a/api/registry/registry.go
+++ b/api/registry/registry.go
@@ -60,9 +60,9 @@ func (r *Registry) NewCarOwnerUsecase() usecase.CarOwnerUsecaseIF {
 
 
 // --- Handler生成 ---
-func (r *Registry) NewCarOwnersHandler() *handler.CarOwnersHandler {
+func (r *Registry) NewCarOwnerHandler() *handler.CarOwnerHandler {
     //*返り値が構造体の場合、ポインタ型は返せません（handler.CarOwnersHandlerは構造体なので、”*”をつけてポインタで返すようにした）
-    return &handler.CarOwnersHandler{
+    return &handler.CarOwnerHandler{
         Usecase: r.NewCarOwnerUsecase(),
     }
 }


### PR DESCRIPTION
# Create HandlerMockTest(FindByID)

### ハンドラーのリファクタリングとルーティングの更新

- コードベース全体で `CarOwnersHandler` を `CarOwnerHandler` に名称統一し、コンストラクタもそれに合わせて修正。
  - 該当ファイル: `api/presentation/http/handler/carowner_handler.go`, `api/registry/registry.go`
- ルーティングロジック（`router.go`）を更新し、`/api/v1/car_owners` および `/api/v1/car_owners/` の両パスで単一の `CarOwnerHandler` インスタンスを使うようにしました。これにより、コレクション（一覧）と個別リソースの両方に対応するハンドラー割当てが簡素化されました。
  - 該当ファイル: `api/presentation/http/router.go`

---

### ハンドラーのロジック改善

- `CarOwnerHandler` の `ServeHTTP` メソッドを修正し、パスベースの分岐で `/api/v1/car_owners`（POST）と `/api/v1/car_owners/{id}`（GET）それぞれに正しい処理が行われるようにしました。
  - 該当ファイル: `api/presentation/http/handler/carowner_handler.go`

---

### テストの強化・更新

- テストファイルで `CarOwnersHandler` から `CarOwnerHandler` への移行を反映し、また Go の最新仕様に合わせて `ioutil.ReadAll` から `io.ReadAll` への変更を行いました。
  - 該当ファイル: `api/presentation/http/handler/fake_carowner_test.go`, `api/presentation/http/handler/mock_carowner_handler_test.go`
- `/api/v1/car_owners/{id}` の GET リクエスト（FindByIDエンドポイント）に対応したテーブル駆動型テストを新規追加。正常系・異常系の両方を網羅しています。
  - 該当ファイル: `api/presentation/http/handler/mock_carowner_handler_test.go`
