### PR TITLE
fix: FindByNameメソッドをCarOwnerRepositoryインターフェースに追加

### DIFF
--- a/api/domain/repository/carowner.go
+++ b/api/domain/repository/carowner.go
@@ -7,7 +7,7 @@ import (
 type CarOwnerRepository interface {
 	Save(carOwner *model.CarOwner) error
 	FindByID(id int) (*model.CarOwner, error)
-	//FindByName(name string)([]*model.CarOwner, error)    //nameに一致する社員の一覧取得
+	FindByName(name string)([]*model.CarOwner, error)    //nameに一致する社員の一覧取得
 	//Update(carOwner *model.CarOwner)error
 	//Delete(id int)error
 }

--- a/api/mocks/fake_carowner.go
+++ b/api/mocks/fake_carowner.go
@@ -8,6 +8,7 @@ import(
 
 type FakeCarOwnerRepo struct{
 	SavedOwner	*model.CarOwner
+	allOwners	[]*model.CarOwner
 }
 
 func (f *FakeCarOwnerRepo) Save (carOwner *model.CarOwner) error {
@@ -35,4 +36,15 @@ func (f *FakeCarOwnerRepo) FindByID(id int) (*model.CarOwner, error) {
 		return nil, fmt.Errorf("IDが不正です(負の数): %v", id)
 	}
     return tempOwner, nil
+}
+
+func (f *FakeCarOwnerRepo) FindByName(name string)([]*model.CarOwner, error) {
+	foundOwners := []*model.CarOwner{}
+
+	for _, owner := range f.allOwners {
+		if owner.IsContainsName(name) {
+			foundOwners = append(foundOwners, owner)
+		}
+	}
+	return foundOwners, nil
 }


### PR DESCRIPTION
このプルリクエストでは、名前で車の所有者を検索できる機能をリポジトリインターフェースとフェイクリポジトリに追加しました。

主な変更点:
- CarOwnerRepository に FindByName(name string) メソッドを追加
- FakeCarOwnerRepo に複数の所有者を保持する allOwners フィールドを追加
- FindByName を実装し、部分一致で所有者を検索・返却できるようにした