### PR TITLE
fix: Goモジュールのキャッシュステップを削除

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,17 +44,6 @@ jobs:
         run: cd api && ls -la
         shell: bash
 
-      - name: Cache Go modules
-        uses: actions/cache@v3
-        continue-on-error: true  # キャッシュエラーを無視
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - name: Install dependencies
         run: go mod tidy
         working-directory: api


### PR DESCRIPTION
CIワークフロー設定への小さな変更：
`actions/cache`を使用してGoモジュールをキャッシュしていたステップを`.github/workflows/ci.yml`ファイルから削除